### PR TITLE
fix request params in common.http.Client and remove roque print intest_im

### DIFF
--- a/stacktester/common/http.py
+++ b/stacktester/common/http.py
@@ -22,5 +22,5 @@ class Client(object):
             params['body'] = kwargs.get('body')
 
         req_url = "%s/%s" % (self.base_url, url)
-        resp, body = self.http_obj.request(req_url, method, **kwargs)
+        resp, body = self.http_obj.request(req_url, method, **params)
         return resp, body

--- a/stacktester/tests/test_images.py
+++ b/stacktester/tests/test_images.py
@@ -115,7 +115,6 @@ class ImagesTest(unittest.TestCase):
 
             self.assertEqual(response['status'], '200')
             result = json.loads(body)
-            print result, expected
             self._assert_image_metadata(result, expected)
 
     def test_get_image_metadata_item(self):


### PR DESCRIPTION
fix request params in common.http.Client and remove roque print intest_images
