### PR TITLE
Configuration objects vs. Dictionary

### DIFF
--- a/bin/stacktester
+++ b/bin/stacktester
@@ -1,24 +1,32 @@
 #!/usr/bin/env python
-
 import optparse
+import os
 import sys
 
 import nose
 
-import stacktester
+import stacktester.config
 
 
 def main():
-    options = parse_options_or_die()
-    stacktester.CONFIG = stacktester.config.load_config(options.config)
+    options = parse_options()
+    stacktester.config.StackConfig._path = os.path.abspath(options.config)
     nose.main(module="stacktester", defaultTest="stacktester.tests")
 
 
-def parse_options_or_die():
+def parse_options():
     parser = optparse.OptionParser()
-    parser.add_option("-c", "--config", dest="config", metavar="FILE",
+    parser.add_option("-c", 
+                      "--config", 
+                      dest="config", 
+                      metavar="FILE",
                       help="Load configuration from FILE.",
                       default="etc/stacktester.cfg")
+    parser.add_option("-v",
+                      "--verbose",
+                      dest="verbose",
+                      action="store_true",
+                      help="Toggle verbose output.")
     options, args = parser.parse_args()
     return options
 

--- a/stacktester/__init__.py
+++ b/stacktester/__init__.py
@@ -1,1 +1,0 @@
-from config import CONFIG

--- a/stacktester/config.py
+++ b/stacktester/config.py
@@ -1,25 +1,83 @@
 import ConfigParser
 
 
-CONFIG = None
+class NovaConfig(object):
+    """Provides configuration information for connecting to Nova."""
 
-def _get_default_config():
-    return {
-        'nova': {
-            'host': "127.0.0.1",
-            'port': 8774,
-            'user': "admin",
-            'base_url': "v1.1/",
-            'api_key': "",
-        },
-        'glance': {
-            'host': "127.0.0.1",
-            'port': 9292
-        },
-    }
+    def __init__(self, conf):
+        """Initialize a Nova-specific configuration object."""
+        self.conf = conf
 
-def load_config(path):
-    defaults = _get_default_config()
-    config = ConfigParser.SafeConfigParser(defaults=defaults)
-    config.read(path)
-    return config
+    def get(self, item_name, default_value):
+        try:
+            return self.conf.get("nova", item_name)
+        except ConfigParser.NoSectionError:
+            return default_value
+
+    @property
+    def host(self):
+        """Host for the Nova HTTP API. Defaults to 127.0.0.1."""
+        return self.get("host", "127.0.0.1")
+
+    @property
+    def port(self):
+        """Port for the Nova HTTP API. Defaults to 8774."""
+        return int(self.get("port", 8774))
+
+    @property
+    def username(self):
+        """Username to use for Nova API requests. Defaults to 'admin'."""
+        return self.get("user", "admin")
+
+    @property
+    def base_url(self):
+        """Base of the HTTP API URL. Defaults to '/v1.1'."""
+        return self.get("base_url", "/v1.1")
+
+    @property
+    def api_key(self):
+        """API key to use when authenticating. Defaults to 'admin_key'."""
+        return self.get("api_key", "admin_key")
+
+
+class GlanceConfig(object):
+    """Provides configuration information for connecting to Glance."""
+
+    def __init__(self, conf):
+        """Initialize a Glance-specific configuration object."""
+        self.conf = conf
+
+    def get(self, item_name, default_value):
+        try:
+            return self.conf.get("glance", item_name)
+        except ConfigParser.NoSectionError:
+            return default_value
+
+    @property
+    def host(self):
+        """Host for the Glance HTTP API. Defaults to '127.0.0.1'."""
+        return self.get("host", "127.0.0.1")
+
+    @property
+    def port(self):
+        """Port for the Glance HTTP API. Defaults to 9292."""
+        return int(self.get("port", 9292))
+
+
+class StackConfig(object):
+    """Provides `stacktester` configuration information."""
+
+    _path = None
+
+    def __init__(self, path=None):
+        """Initialize a configuration from a path."""
+        self._path = path or self._path
+        self._conf = self.load_config(self._path)
+        self.glance = GlanceConfig(self._conf)
+        self.nova = NovaConfig(self._conf)
+
+    def load_config(self, path=None):
+        """Read configuration from given path and return a config object."""
+        config = ConfigParser.SafeConfigParser()
+        config.read(path)
+        return config

--- a/stacktester/nova.py
+++ b/stacktester/nova.py
@@ -38,7 +38,7 @@ class API(common.http.Client):
             print "Failed to authenticate user"
             raise
 
-        #TODO: use management_url <== what does this mean?
+        #TODO: use management_url
 
     def wait_for_server_status(self, server_id, status='ACTIVE', **kwargs):
         """Wait for the server status to be equal to the status passed in.

--- a/stacktester/nova.py
+++ b/stacktester/nova.py
@@ -1,15 +1,35 @@
-
 import common.http
 import json
 import subprocess
 
+
 class API(common.http.Client):
-    def __init__(self, host, port, base_url, user, apikey):
+    """Barebones Nova HTTP API client."""
+
+    def __init__(self, host, port, base_url, user, api_key):
+        """Initialize Nova HTTP API client.
+
+        :param host: Hostname/IP of the Nova API to test.
+        :param port: Port of the Nova API to test.
+        :param base_url: Version identifier (normally /v1.0 or /v1.1)
+        :param user: The username to use for tests.
+        :param api_key: The API key of the user.
+        :returns: None
+
+        """
         super(API, self).__init__(host, port, base_url)
         self.user = user
-        self.apikey = apikey
+        self.api_key = api_key
 
-    def _authenticate(self, user, api_key):
+    def authenticate(self, user, api_key):
+        """Request and return an authentication token from Nova.
+
+        :param user: The username we're authenticating.
+        :param api_key: The API key for the user we're authenticating.
+        :returns: Authentication token (string)
+        :raises: KeyError if authentication fails.
+
+        """
         headers = {'X-Auth-User': user, 'X-Auth-Key': api_key}
         resp, body = super(API, self).request('GET', '', headers=headers)
         try:
@@ -18,39 +38,75 @@ class API(common.http.Client):
             print "Failed to authenticate user"
             raise
 
-        #TODO: use management_url
+        #TODO: use management_url <== what does this mean?
 
-    def wait_for_server_status(self, serverid, status='ACTIVE', **kwargs):
+    def wait_for_server_status(self, server_id, status='ACTIVE', **kwargs):
+        """Wait for the server status to be equal to the status passed in.
 
+        :param server_id: Server ID to query.
+        :param status: The status string to look for.
+        :returns: None
+
+        """
         def check_response(resp, body):
             data = json.loads(body)
             return data['server']['status'] == status
 
         self.poll_request(
-            'GET', 
-            '/servers/%s' % serverid, 
-            check_response, 
+            'GET',
+            '/servers/%s' % server_id,
+            check_response,
             **kwargs)
 
     def request(self, method, url, **kwargs):
+        """Generic HTTP request on the Nova API.
+
+        :param method: Request verb to use (GET, PUT, POST, etc.)
+        :param url: The API resource to request.
+        :param kwargs: Additional keyword arguments to pass to the request.
+        :returns: HTTP response object.
+
+        """
         headers = kwargs.get('headers', {})
-        headers['X-Auth-Token'] = self._authenticate(self.user, self.apikey)
+        headers['X-Auth-Token'] = self.authenticate(self.user, self.api_key)
         kwargs['headers'] = headers
         return super(API, self).request(method, url, **kwargs)
 
-    def _add_flavor(self, flavor):
-        #TODO: Get connection info from config
-        subprocess.call(["ssh", "root@nova1", "nova-manage instance_type create", 
-                        str(flavor["name"]),
-                        str(flavor["ram"]),
-                        str(flavor["vcpus"]),
-                        str(flavor["disk"]),
-                        str(flavor["flavorid"]),
-        ]) 
+    def add_flavor(self, flavor):
+        """Add a flavor, using the 'nova-manage' command via SSH.
 
-    def _delete_flavor(self, flavor_name):
+        :param flavor: Dictionary describing a flavor to add to Nova's DB.
+        :returns: None
+
+        """
         #TODO: Get connection info from config
-        subprocess.call(["ssh", "root@nova1", "nova-manage instance_type delete ",
-                    flavor_name,
-                    "--purge",
-            ]) 
+        #TODO: Support passwords
+        #TODO: Use paramiko
+        subprocess.call([
+            "ssh",
+            "root@nova1",
+            "nova-manage instance_type create",
+            str(flavor["name"]),
+            str(flavor["ram"]),
+            str(flavor["vcpus"]),
+            str(flavor["disk"]),
+            str(flavor["flavorid"]),
+        ])
+
+    def delete_flavor(self, flavor_name):
+        """Delete a flavor, using the 'nova-manage' command via SSH.
+
+        :param flavor_name: The name of the flavor to delete.
+        :returns: None
+
+        """
+        #TODO: Get connection info from config
+        #TODO: Support passwords
+        #TODO: Use paramiko
+        subprocess.call([
+            "ssh",
+            "root@nova1",
+            "nova-manage instance_type delete ",
+            flavor_name,
+            "--purge",
+        ])

--- a/stacktester/openstack.py
+++ b/stacktester/openstack.py
@@ -1,27 +1,26 @@
-
-import stacktester
-from stacktester import nova
 import glance.client
+
+import stacktester.config
+import stacktester.nova
 
 
 class Manager(object):
     """Top-level object to access OpenStack resources."""
 
-    def __init__(self, config=None):
-        if config is None:
-            config = stacktester.CONFIG
-        self.nova_api = self._load_nova_api(config)
-        self.glance_client = self._load_glance_client(config)
+    def __init__(self):
+        config = stacktester.config.StackConfig()
+        self.nova = self._load_nova(config)
+        self.glance = self._load_glance(config)
 
-    def _load_nova_api(self, config):
-        host = config.get('nova', 'host')
-        port = config.getint('nova', 'port')
-        base_url = config.get('nova', 'base_url')
-        user = config.get('nova', 'user')
-        api_key = config.get('nova', 'api_key')
-        return nova.API(host, port, base_url, user, api_key)
+    def _load_nova(self, config):
+        host = config.nova.host
+        port = config.nova.port
+        base_url = config.nova.base_url
+        user = config.nova.username
+        api_key = config.nova.api_key
+        return stacktester.nova.API(host, port, base_url, user, api_key)
 
-    def _load_glance_client(self, config):
-        host = config.get('nova', 'host')
-        port = config.getint('nova', 'port')
+    def _load_glance(self, config):
+        host = config.glance.host
+        port = config.glance.port
         return glance.client.Client(host, port)

--- a/stacktester/tests/test_flavors.py
+++ b/stacktester/tests/test_flavors.py
@@ -11,7 +11,7 @@ FIXTURES = [
     {"flavorid": 3, "name": "m1.medium", "ram": 4096, "vcpus": 2, "disk": 40},
     {"flavorid": 4, "name": "m1.large", "ram": 8192, "vcpus": 4, "disk": 80},
     {"flavorid": 5, "name": "m1.xlarge", "ram": 16384, "vcpus": 8, "disk": 160},
-] 
+]
 
 
 class FlavorsTest(unittest.TestCase):
@@ -21,11 +21,11 @@ class FlavorsTest(unittest.TestCase):
         self.flavors = {}
         for FIXTURE in FIXTURES:
             self.flavors[FIXTURE["name"]] = FIXTURE
-            self.os.nova_api._add_flavor(FIXTURE)
+            self.os.nova.add_flavor(FIXTURE)
 
     def tearDown(self):
        for FIXTURE in FIXTURES:
-           self.os.nova_api._delete_flavor(FIXTURE["name"])
+           self.os.nova.delete_flavor(FIXTURE["name"])
 
     def test_get_flavor_details(self):
         """
@@ -34,7 +34,7 @@ class FlavorsTest(unittest.TestCase):
         self.assertEqual(len(self.flavors.items()), len(FIXTURES))
         for (flavor_name, expected) in self.flavors.items():
             url = '/flavors/%s' % (expected['flavorid'])
-            response, body = self.os.nova_api.request('GET', url)
+            response, body = self.os.nova.request('GET', url)
             self.assertEqual(response['status'], '200')
             actual = json.loads(body)['flavor']
             self.assertEqual(expected['name'], actual['name'])
@@ -47,13 +47,13 @@ class FlavorsTest(unittest.TestCase):
         """
 
         url = '/flavors'
-        response, body = self.os.nova_api.request('GET', url)
+        response, body = self.os.nova.request('GET', url)
         self.assertEqual(response['status'], '200')
         actuals = json.loads(body)['flavors']
 
         for actual in actuals:
             print actual
-            
+
             expected= self.flavors[actual['name']]
 
             self.assertEqual(response['status'], '200')
@@ -65,13 +65,13 @@ class FlavorsTest(unittest.TestCase):
         """
 
         url = '/flavors/detail'
-        response, body = self.os.nova_api.request('GET', url)
+        response, body = self.os.nova.request('GET', url)
         self.assertEqual(response['status'], '200')
         actuals = json.loads(body)['flavors']
 
         for actual in actuals:
             print actual
-            
+
             expected= self.flavors[actual['name']]
 
             self.assertEqual(response['status'], '200')

--- a/stacktester/tests/test_images.py
+++ b/stacktester/tests/test_images.py
@@ -34,12 +34,12 @@ class ImagesTest(unittest.TestCase):
         self.os = openstack.Manager()
         self.images = {}
         for FIXTURE in FIXTURES:
-            meta = self.os.glance_client.add_image(FIXTURE, None)
+            meta = self.os.glance.add_image(FIXTURE, None)
             self.images[str(meta['id'])] = meta
 
     def tearDown(self):
         for (image_id, meta) in self.images.items():
-            self.os.glance_client.delete_image(image_id)
+            self.os.glance.delete_image(image_id)
 
     def _assert_image_basic(self, image, expected):
         self.assertEqual(expected['id'], image['id'])
@@ -71,7 +71,7 @@ class ImagesTest(unittest.TestCase):
 
     def test_get_images(self):
         """Verify the correct list of image entities is returned"""
-        response, body = self.os.nova_api.request('GET', '/images')
+        response, body = self.os.nova.request('GET', '/images')
 
         self.assertEqual(response['status'], '200')
         result = json.loads(body)['images']
@@ -85,7 +85,7 @@ class ImagesTest(unittest.TestCase):
 
     def test_get_images_detailed(self):
         """Verify the correct list of detailed image entities is returned"""
-        response, body = self.os.nova_api.request('GET', '/images/detail')
+        response, body = self.os.nova.request('GET', '/images/detail')
 
         self.assertEqual(response['status'], '200')
         result = json.loads(body)['images']
@@ -101,7 +101,7 @@ class ImagesTest(unittest.TestCase):
         """Verify the correct entities are returned for each image"""
         for (image_id, expected) in self.images.items():
             url = '/images/%s' % (image_id,)
-            response, body = self.os.nova_api.request('GET', url)
+            response, body = self.os.nova.request('GET', url)
 
             self.assertEqual(response['status'], '200')
             result = json.loads(body)['image']
@@ -111,7 +111,7 @@ class ImagesTest(unittest.TestCase):
         """Verify correct list of metadata entities are returned per image"""
         for (image_id, expected) in self.images.items():
             url = '/images/%s/meta' % (image_id,)
-            response, body = self.os.nova_api.request('GET', url)
+            response, body = self.os.nova.request('GET', url)
 
             self.assertEqual(response['status'], '200')
             result = json.loads(body)
@@ -122,7 +122,7 @@ class ImagesTest(unittest.TestCase):
         for (image_id, expected) in self.images.items():
             for (meta_key, meta_value) in expected['properties'].items():
                 url = '/images/%s/meta/%s' % (image_id, meta_key)
-                response, body = self.os.nova_api.request('GET', url)
+                response, body = self.os.nova.request('GET', url)
 
                 self.assertEqual(response['status'], '200')
                 result = json.loads(body)

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -53,22 +53,22 @@ class ServersTest(unittest.TestCase):
             }
         })
 
-        response, body = self.os.nova_api.request('POST','/servers',body=body)
+        response, body = self.os.nova.request('POST','/servers',body=body)
 
         data = json.loads(body)
         serverid = data['server']['id']
         self.assertEqual(200, int(response['status']))
-        self.os.nova_api.wait_for_server_status(serverid, 'ACTIVE')
+        self.os.nova.wait_for_server_status(serverid, 'ACTIVE')
 
         self.assertEqual('testserver', data['server']['name'])
 
-        response, body = self.os.nova_api.request(
+        response, body = self.os.nova.request(
             'DELETE',
-            '/servers/%s' % serverid, 
+            '/servers/%s' % serverid,
             body=body)
 
         # Raises TimeOutException on failure
-        self.os.nova_api.poll_request_status('GET', '/servers/%s' % serverid, 404)
+        self.os.nova.poll_request_status('GET', '/servers/%s' % serverid, 404)
 
     #def test_update_server_name(self):
         #"""

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -56,19 +56,19 @@ class ServersTest(unittest.TestCase):
         response, body = self.os.nova.request('POST','/servers',body=body)
 
         data = json.loads(body)
-        serverid = data['server']['id']
+        server_id = data['server']['id']
         self.assertEqual(200, int(response['status']))
-        self.os.nova.wait_for_server_status(serverid, 'ACTIVE')
+        self.os.nova.wait_for_server_status(server_id, 'ACTIVE')
 
         self.assertEqual('testserver', data['server']['name'])
 
         response, body = self.os.nova.request(
             'DELETE',
-            '/servers/%s' % serverid,
+            '/servers/%s' % server_id,
             body=body)
 
         # Raises TimeOutException on failure
-        self.os.nova.poll_request_status('GET', '/servers/%s' % serverid, 404)
+        self.os.nova.poll_request_status('GET', '/servers/%s' % server_id, 404)
 
     #def test_update_server_name(self):
         #"""


### PR DESCRIPTION
I agree with Mark that defaults are a good thing to have, so that a configuration file is not required. Making object allows for easy viewing of defaults:

$ pydoc stacktester.config

or, more specifically:

$ pydoc stacktester.config.NovaConfig
$ pydoc stacktester.config.GlanceConfig

Waldon, please don't taze me because this change-set has a bunch of different refactorings...I'm really bad about going off on a tangent. I'll split this up if you'd like :) Config changes in one and name changing  in another.
