### PR TITLE
Real Image Fixtures and More Servers Tests

### DIFF
--- a/etc/stacktester.cfg
+++ b/etc/stacktester.cfg
@@ -8,6 +8,6 @@ api_key=d9DBcehAEiPAEoAZAb1e
 [glance]
 host=127.0.0.1
 port=9292
-image_uri=http://c625682.r82.cf2.rackcdn.com/image
-kernel_uri=http://c625682.r82.cf2.rackcdn.com/kernel
-ramdisk_uri=http://c625682.r82.cf2.rackcdn.com/ramdisk 
+ami_uri=http://c625682.r82.cf2.rackcdn.com/image
+aki_uri=http://c625682.r82.cf2.rackcdn.com/kernel
+ari_uri=http://c625682.r82.cf2.rackcdn.com/ramdisk 

--- a/etc/stacktester.cfg
+++ b/etc/stacktester.cfg
@@ -8,3 +8,6 @@ api_key=d9DBcehAEiPAEoAZAb1e
 [glance]
 host=127.0.0.1
 port=9292
+image_uri=http://c625682.r82.cf2.rackcdn.com/image
+kernel_uri=http://c625682.r82.cf2.rackcdn.com/kernel
+ramdisk_uri=http://c625682.r82.cf2.rackcdn.com/ramdisk 

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -57,7 +57,7 @@ class ServersTest(unittest.TestCase):
 
         data = json.loads(body)
         serverid = data['server']['id']
-        self.assertEqual(200, int(response['status']))
+        self.assertEqual(202, int(response['status']))
         self.os.nova_api.wait_for_server_status(serverid, 'ACTIVE')
 
         self.assertEqual('testserver', data['server']['name'])

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import stacktester
 from stacktester import exceptions
 from stacktester import openstack
 
@@ -20,10 +21,44 @@ import json
 import unittest
 
 
+SERVER_FIXTURES = [
+    {
+        'server' : {
+            'name' : 'testserver',
+            'imageRef' : 3,
+            'flavorRef' : 1,
+        }
+    },
+]
+
+IMAGE_FIXTURES = [
+    {
+        'name': 'Image1',
+        'disk_format': 'vdi',
+        'container_format': 'ovf',
+        'is_public': False,
+        'properties': {
+            'key1': 'value1',
+        }
+    },
+    {
+        'name': 'Image2',
+        'disk_format': 'vdi',
+        'container_format': 'ovf',
+        'is_public': True,
+        'properties': {
+            'key2': 'value2',
+            'key3': 'value3',
+        }
+    },
+]
+
+
 class ServersTest(unittest.TestCase):
 
     def setUp(self):
         self.os = openstack.Manager()
+        #self.config = stacktester.CONFIG
 
     def tearDown(self):
         pass
@@ -45,7 +80,7 @@ class ServersTest(unittest.TestCase):
         Verify that a server instance can be created and deleted
         """
 
-        body = json.dumps({
+        post_body = json.dumps({
             'server' : {
                 'name' : 'testserver',
                 'imageRef' : 3,
@@ -53,12 +88,13 @@ class ServersTest(unittest.TestCase):
             }
         })
 
-        response, body = self.os.nova.request('POST','/servers',body=body)
+        response, body = self.os.nova.request(
+            'POST', '/servers', body=post_body)
 
         data = json.loads(body)
         server_id = data['server']['id']
-        self.assertEqual(202, int(response['status']))
-        self.os.nova.wait_for_server_status(server_id, 'ACTIVE')
+        self.assertEqual('202', response['status'])
+        self.os.nova.wait_for_server_status(serverid, 'ACTIVE')
 
         self.assertEqual('testserver', data['server']['name'])
 
@@ -70,24 +106,66 @@ class ServersTest(unittest.TestCase):
         # Raises TimeOutException on failure
         self.os.nova.poll_request_status('GET', '/servers/%s' % server_id, 404)
 
-    #def test_update_server_name(self):
-        #"""
-        #Verify the name of an instance can be changed
-        #"""
+    def test_update_server_name(self):
+        """
+        Verify the name of an instance can be changed
+        """
 
-        #self.server.update_name(name='modifiedName')
-        #self.server.waitForStatus('ACTIVE')
+        post_body = json.dumps({
+            'server' : {
+                'name' : 'testserver',
+                'imageRef' : 3,
+                'flavorRef' : 1,
+            }
+        })
 
-        #updatedServer = self.os.servers.get(self.server.id)
-        #self.assertEqual('modifiedName', updatedServer.name)
+        # Create Server
+        resp, body = self.os.nova.request(
+            'POST', '/servers', body=post_body)
+        
+        #self.assertEqual(resp['status'], '202')
+        data = json.loads(body)
+        serverid = data['server']['id']
+        self.assertTrue(data['server']['name'], 'testserver')
 
-    #def test_create_server_invalid_image(self):
-        #"""
-        #Verify that creating a server with an unknown image ref will fail
-        #"""
-        #newServer = self.os.servers.create(name="testserver2",
-        #image="http://glance1:9292/v1/images/9999",
-        #flavor="http://172.19.0.3:8774/v1.1/flavors/3")
+        # Wait for it to be created
+        self.os.nova.wait_for_server_status(serverid, 'ACTIVE')
+
+        # Update name
+        put_body = json.dumps({
+            'server' : {
+                'name' : 'updatedtestserver'
+            }
+        })
+        resp, body = self.os.nova.request(
+            'PUT', '/servers/%s' % serverid, body=put_body)
+
+        self.assertEqual(resp['status'], '204')
+
+        # Get Server information
+        resp, body = self.os.nova.request('GET', '/servers/%s' % serverid)
+
+        self.assertEqual(resp['status'], '202')
+        data = json.loads(body)
+        self.assertEqual(data['server']['name'], 'updatedtestserver')
+        
+    def test_create_server_invalid_image(self):
+        """
+        Verify that creating a server with an unknown image ref will fail
+        """
+
+        post_body = json.dumps({
+            'server' : {
+                'name' : 'testserver',
+                'imageRef' : 302,
+                'flavorRef' : 1,
+            }
+        })
+
+        resp, body = self.os.nova.request(
+            'POST', '/servers', body=post_body)
+
+        self.assertTrue(resp['status'], '400')
 
     #def test_create_server_invalid_flavor(self):
         #"""


### PR DESCRIPTION
Added glance config options for image uri's, and use them through IMAGE_FIXTURES in test_servers.  This stuff should probably be moved out somewhere generic so that any test suite can use them, but I think this gets us started.
