### PR TITLE
Things we discussed?

### DIFF
--- a/stacktester/nova.py
+++ b/stacktester/nova.py
@@ -61,7 +61,7 @@ class API(stacktester.common.http.Client):
             '/servers/%s' % server_id,
             check_response,
             **kwargs)
-    
+
     #TODO Consider genericizing so servers/images share common code
     def wait_for_image_status(self, image_id, status='ACTIVE', **kwargs):
         """Wait for the image status to be equal to the status passed in.
@@ -94,75 +94,3 @@ class API(stacktester.common.http.Client):
         headers['X-Auth-Token'] = self.authenticate(self.user, self.api_key)
         kwargs['headers'] = headers
         return super(API, self).request(method, url, **kwargs)
-
-
-class AdminClient(object):
-    """Administrative client for remotely managing Nova installations."""
-
-    def __init__(self, host, ssh_port, ssh_username):
-        """Initialize an admin client.
-
-        :param host: The hostname/IP of a Nova node with nova-manage installed.
-        :param ssh_port: The ssh port of a Nova node with nova-manage installed.
-        :param ssh_username: The username to use via SSH to execute commands.
-        :returns: None
-
-        """
-        self.host = host
-        self.ssh_port = ssh_port
-        self.ssh_username = ssh_username
-        self._ssh = self._connect()
-
-    def _connect(self):
-        """Setup the SSH client to connect to the target server."""
-        self._set_paramiko_logging()
-        client = paramiko.SSHClient()
-        client.load_system_host_keys()
-        client.connect(self.host, port=self.ssh_port,
-                       username=self.ssh_username)
-        return client
-
-    def _set_paramiko_logging(self):
-        """Move from DEBUG -> WARN level logging on paramiko."""
-        logger = logging.getLogger("paramiko.transport")
-        logger.setLevel(logging.WARN)
-
-    def _remote_call(self, command):
-        """Perform a command on the remote node.
-
-        :param command: The command to perform, including all options/flags.
-        :returns: True if exit code == 0, False if exit code != 0
-
-        """
-        session = self._ssh.get_transport().open_session()
-        stdin, stdout, stderr = session.exec_command(command)
-        exit_code = session.recv_exit_status()
-        success = exit_code == 0
-
-        if not success:
-            print "%(command)s returned %(exit_code)d" % locals()
-            print "Standard Out: %(stdout)s" % locals()
-            print "Standard Error: %(stderr)s" % locals()
-
-        return success
-
-    def add_flavor(self, flavor):
-        """Add a flavor, using the 'nova-manage' command via SSH.
-
-        :param flavor: Dictionary describing a flavor to add to Nova's DB.
-        :returns: None
-
-        """
-        self._ssh.exec_command("nova-manage instance_type create %(name)s "
-                               "%(ram)s %(vcpus)s %(disk)s %(flavorid)s" %
-                               flavor)
-
-    def delete_flavor(self, flavor_name):
-        """Delete a flavor, using the 'nova-manage' command via SSH.
-
-        :param flavor_name: The name of the flavor to delete.
-        :returns: None
-
-        """
-        self._ssh.exec_command("nova-manage instance_type delete "
-                               "%(flavor_name)s --purge" % locals())

--- a/stacktester/openstack.py
+++ b/stacktester/openstack.py
@@ -1,5 +1,3 @@
-import glance.client
-
 import stacktester.config
 import stacktester.nova
 
@@ -9,21 +7,8 @@ class Manager(object):
 
     def __init__(self):
         config = stacktester.config.StackConfig()
-        self.nova = self._load_nova(config)
-        self.nova_admin = self._load_nova_admin(config)
-        self.glance = self._load_glance(config)
-
-    def _load_nova(self, config):
-        return stacktester.nova.API(config.nova.host,
-                                    config.nova.port,
-                                    config.nova.base_url,
-                                    config.nova.username,
-                                    config.nova.api_key)
-
-    def _load_nova_admin(self, config):
-        return stacktester.nova.AdminClient(config.nova.host,
-                                            config.nova.ssh_port,
-                                            config.nova.ssh_username)
-
-    def _load_glance(self, config):
-        return glance.client.Client(config.glance.host, config.glance.port)
+        self.nova = stacktester.nova.API(config.nova.host,
+                                         config.nova.port,
+                                         config.nova.base_url,
+                                         config.nova.username,
+                                         config.nova.api_key)

--- a/stacktester/tests/test_flavors.py
+++ b/stacktester/tests/test_flavors.py
@@ -1,15 +1,8 @@
-
-
-from stacktester import openstack
-
 import json
+
 import unittest2 as unittest
 
-#TODO: only for optional setup
-FIXTURES = [
-    {"flavorid": 1, "name": "m1.tiny", "ram": 512, "vcpus": 1, "disk": 0},
-    {"flavorid": 2, "name": "m1.small", "ram": 2048, "vcpus": 1, "disk": 20},
-]
+from stacktester import openstack
 
 
 class FlavorsTest(unittest.TestCase):

--- a/stacktester/tests/test_images.py
+++ b/stacktester/tests/test_images.py
@@ -51,7 +51,6 @@ class ImagesTest(unittest.TestCase):
         response, body = self.os.nova.request(
             'POST', '/servers', body=post_body)
         data = json.loads(body)
-        print data
         server_id = data['server']['id']
         self.os.nova.wait_for_server_status(server_id, 'ACTIVE')
 

--- a/stacktester/tests/test_images.py
+++ b/stacktester/tests/test_images.py
@@ -1,45 +1,14 @@
-
-from stacktester import openstack
-
 import json
+
 import unittest2 as unittest
 
-
-FIXTURES = [
-    {
-        'name': 'Image1',
-        'disk_format': 'vdi',
-        'container_format': 'ovf',
-        'is_public': False,
-        'properties': {
-            'key1': 'value1',
-        }
-    },
-    {
-        'name': 'Image2',
-        'disk_format': 'vdi',
-        'container_format': 'ovf',
-        'is_public': True,
-        'properties': {
-            'key2': 'value2',
-            'key3': 'value3',
-        }
-    },
-]
+from stacktester import openstack
 
 
 class ImagesTest(unittest.TestCase):
 
     def setUp(self):
         self.os = openstack.Manager()
-        self.images = {}
-        for FIXTURE in FIXTURES:
-            meta = self.os.glance.add_image(FIXTURE, None)
-            self.images[str(meta['id'])] = meta
-
-    def tearDown(self):
-        for (image_id, meta) in self.images.items():
-            self.os.glance.delete_image(image_id)
 
     def _assert_image_basic(self, image, expected):
         self.assertEqual(expected['id'], image['id'])
@@ -69,65 +38,6 @@ class ImagesTest(unittest.TestCase):
 
         self._assert_image_metadata(image, expected)
 
-    def test_get_images(self):
-        """Verify the correct list of image entities is returned"""
-        response, body = self.os.nova.request('GET', '/images')
-
-        self.assertEqual(response['status'], '200')
-        result = json.loads(body)['images']
-
-        # expect to only see public images
-        self.assertEqual(len(result), 1)
-
-        for image in result:
-            expected = self.images[str(image['id'])]
-            self._assert_image_basic(image, expected)
-
-    def test_get_images_detailed(self):
-        """Verify the correct list of detailed image entities is returned"""
-        response, body = self.os.nova.request('GET', '/images/detail')
-
-        self.assertEqual(response['status'], '200')
-        result = json.loads(body)['images']
-
-        # expect to only see public images
-        self.assertEqual(len(result), 1)
-
-        for image in result:
-            expected = self.images[str(image['id'])]
-            self._assert_image_detailed(image, expected)
-
-    def test_get_image(self):
-        """Verify the correct entities are returned for each image"""
-        for (image_id, expected) in self.images.items():
-            url = '/images/%s' % (image_id,)
-            response, body = self.os.nova.request('GET', url)
-
-            self.assertEqual(response['status'], '200')
-            result = json.loads(body)['image']
-            self._assert_image_detailed(result, expected)
-
-    def test_get_image_metadata(self):
-        """Verify correct list of metadata entities are returned per image"""
-        for (image_id, expected) in self.images.items():
-            url = '/images/%s/meta' % (image_id,)
-            response, body = self.os.nova.request('GET', url)
-
-            self.assertEqual(response['status'], '200')
-            result = json.loads(body)
-            self._assert_image_metadata(result, expected)
-
-    def test_get_image_metadata_item(self):
-        """Verify the correct metadata entities are returned for each image"""
-        for (image_id, expected) in self.images.items():
-            for (meta_key, meta_value) in expected['properties'].items():
-                url = '/images/%s/meta/%s' % (image_id, meta_key)
-                response, body = self.os.nova.request('GET', url)
-
-                self.assertEqual(response['status'], '200')
-                result = json.loads(body)
-                self.assertEqual(result, {'meta': {meta_key: meta_value}})
-
     def test_create_delete_server_image(self):
         """Verify an image can be created from an existing server"""
         post_body = json.dumps({
@@ -141,20 +51,22 @@ class ImagesTest(unittest.TestCase):
         response, body = self.os.nova.request(
             'POST', '/servers', body=post_body)
         data = json.loads(body)
+        print data
         server_id = data['server']['id']
         self.os.nova.wait_for_server_status(server_id, 'ACTIVE')
 
         post_body = json.dumps({
             'image' : {
                 'name' : 'backup',
-                'serverRef' : str(server_id)               
+                'serverRef' : str(server_id)
             }
         })
         response, body = self.os.nova.request(
             'POST', '/images', body=post_body)
 
-        #TODO Ignoring the incorrect response code so the test can continue        
+        #TODO Ignoring the incorrect response code so the test can continue
         #self.assertEqual(response['status'], '202')
+
         data = json.loads(body)
         image_id = data['image']['id']
         self.os.nova.wait_for_image_status(image_id, 'ACTIVE')

--- a/stacktester/tests/test_server_actions.py
+++ b/stacktester/tests/test_server_actions.py
@@ -36,7 +36,6 @@ class ServersTest(unittest.TestCase):
             'POST', '/servers', body=post_body)
 
         data = json.loads(body)
-        print body
         self.server_id = data['server']['id']
         self.os.nova.wait_for_server_status(self.server_id, 'ACTIVE')
 

--- a/stacktester/tests/test_server_actions.py
+++ b/stacktester/tests/test_server_actions.py
@@ -12,19 +12,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import json
 
-import stacktester
-from stacktester import exceptions
 from stacktester import openstack
 
-import json
 import unittest2 as unittest
+
 
 class ServersTest(unittest.TestCase):
 
     def setUp(self):
         self.os = openstack.Manager()
-        self.config = stacktester.config.StackConfig()
 
         post_body = json.dumps({
             'server' : {
@@ -36,7 +34,7 @@ class ServersTest(unittest.TestCase):
 
         response, body = self.os.nova.request(
             'POST', '/servers', body=post_body)
-        
+
         data = json.loads(body)
         print body
         self.server_id = data['server']['id']
@@ -88,27 +86,3 @@ class ServersTest(unittest.TestCase):
         self.os.nova.wait_for_server_status(self.server_id, 'ACTIVE')
 
         #TODO: SSH into server using new password
-
-#    def test_resize_server_confirm(self):
-#        
-#        post_body = json.dumps({
-#            'resize' : {
-#                'flavor' : {
-#                    'flavorRef': 2                
-#                }
-#            }
-#        })
-#
-#        response, body = self.os.nova.request(
-#            'POST', '/servers/%s/action' % self.server_id, body=post_body)
-#        self.assertEqual('202', response['status'])
-#        self.os.nova.wait_for_server_status(self.server_id, 'VERIFY_RESIZE')
-#
-#        post_body = json.dumps({
-#            'confirmResize' : 'null'
-#        })
-#
-#        response, body = self.os.nova.request(
-#            'POST', '/servers/%s/action' % self.server_id, body=post_body)
-#        self.assertEqual('204', response['status'])
-#        self.os.nova.wait_for_server_status(self.server_id, 'ACTIVE')

--- a/stacktester/tests/test_server_meta.py
+++ b/stacktester/tests/test_server_meta.py
@@ -12,19 +12,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import json
 
-import stacktester
-from stacktester import exceptions
+import unittest2 as unittest
+
 from stacktester import openstack
 
-import json
-import unittest2 as unittest
 
 class ServersMetadataTest(unittest.TestCase):
 
     def setUp(self):
         self.os = openstack.Manager()
-        self.config = stacktester.config.StackConfig()
 
         post_body = json.dumps({
             'server' : {
@@ -39,12 +37,12 @@ class ServersMetadataTest(unittest.TestCase):
 
         response, body = self.os.nova.request(
             'POST', '/servers', body=post_body)
-        
+
         data = json.loads(body)
+        print data
 
         self.server_id = data['server']['id']
         self.os.nova.wait_for_server_status(self.server_id, 'ACTIVE')
-
 
     def tearDown(self):
         self.os.nova.request('DELETE', '/servers/%s' % self.server_id)
@@ -53,47 +51,5 @@ class ServersMetadataTest(unittest.TestCase):
         """Test that we can retrieve metadata for a server"""
 
         response, body = self.os.nova.request('GET', '/servers/%s/meta' % self.server_id)
-        result = json.loads(body)['metadata']        
+        result = json.loads(body)['metadata']
         self.assertEqual(result['testEntry'], 'testValue')
-
-#    def test_add_server_metadata(self):
-#        """Verify that key/value pairs can be added to a server's metadata"""
-#
-#        put_body = json.dumps({
-#            'metadata' : {
-#                'server label' : 'Web1',
-#                'version' : '11.0'
-#            }
-#        })
-#
-#        response, body = self.os.nova.request(
-#            'PUT', '/servers/%s/meta' % self.server_id, body=put_body)
-#        
-#        #self.assertEqual('201', response['status'])       
-#        result = json.loads(body)['metadata']
-#        self.assertEqual(result['server label'], 'Web1')
-#        self.assertEqual(result['version'], '11.0')
-#        if 'testEntry' in result: self.fail('This entry should be overwritten.')
-#
-#    def test_update_server_metadata(self):
-#        """Verify that the metadata for a server can be updated"""
-#    
-#        post_body = json.dumps({
-#            'metadata' : {
-#                'key' : 'old'
-#            }
-#        })
-#        response, body = self.os.nova.request(
-#            'POST', '/servers/%s/meta' % self.server_id, body=post_body)
-#        self.assertEqual('201', response['status'])
-#        
-#        post_body = json.dumps({
-#            'metadata' : {
-#                'key' : 'new'
-#            }
-#        })
-#        response, body = self.os.nova.request(
-#            'POST', '/servers/%s/meta' % self.server_id, body=post_body)
-#        self.assertEqual('201', response['status'])
-#        result = json.loads(body)['metadata']        
-#        self.assertEqual(result['key'], 'new')

--- a/stacktester/tests/test_server_meta.py
+++ b/stacktester/tests/test_server_meta.py
@@ -39,7 +39,6 @@ class ServersMetadataTest(unittest.TestCase):
             'POST', '/servers', body=post_body)
 
         data = json.loads(body)
-        print data
 
         self.server_id = data['server']['id']
         self.os.nova.wait_for_server_status(self.server_id, 'ACTIVE')

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -41,7 +41,6 @@ class ServersTest(unittest.TestCase):
             'POST', '/servers', body=post_body)
 
         data = json.loads(body)
-        print data
 
         server_id = data['server']['id']
         self.assertEqual('202', response['status'])

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -12,19 +12,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import json
 
-import stacktester
-from stacktester import exceptions
+import unittest2 as unittest
+
 from stacktester import openstack
 
-import json
-import unittest2 as unittest
 
 class ServersTest(unittest.TestCase):
 
     def setUp(self):
         self.os = openstack.Manager()
-        self.config = stacktester.config.StackConfig()
 
     def test_create_delete_server(self):
         """
@@ -43,6 +41,7 @@ class ServersTest(unittest.TestCase):
             'POST', '/servers', body=post_body)
 
         data = json.loads(body)
+        print data
 
         server_id = data['server']['id']
         self.assertEqual('202', response['status'])
@@ -118,12 +117,3 @@ class ServersTest(unittest.TestCase):
             'POST', '/servers', body=post_body)
 
         self.assertTrue(resp['status'], '400')
-
-    #def test_create_server_invalid_flavor(self):
-        #"""
-        #Verify that creating a server with an unknown image ref will fail
-        #"""
-
-        #newServer = self.os.servers.create(name="testserver2",
-        #image="http://glance1:9292/v1/images/1",
-        #flavor="http://172.19.0.3:8774/v1.1/flavors/99999999")

--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -1,5 +1,3 @@
 httplib2
-glance
 nose
-paramiko
 unittest2


### PR DESCRIPTION
Removal of most/all of admin client code, or anything that tears down / builds testing environment. Also included print statements to show where/how current tests are failing. Next step is to make these tests fail gracefully and with known failure markers.
