### PR TITLE
fixed issue with poll_request timeout

### DIFF
--- a/stacktester/common/http.py
+++ b/stacktester/common/http.py
@@ -24,7 +24,7 @@ class Client(object):
             resp, body = self.request(method, url, **kwargs)
             if (check_response(resp, body)):
                 break
-            if (int(time.time()) - start_ts >= (timeout * 1000)):
+            if (int(time.time()) - start_ts >= timeout):
                 raise exceptions.TimeoutException
             time.sleep(interval)
 


### PR DESCRIPTION
Silly issue, time.time() is already in seconds, not msec.  The default timeout before this change was 3,000 minutes instead of 3 minutes :)
