### PR TITLE
Tenant Id updates

### DIFF
--- a/stacktester/common/http.py
+++ b/stacktester/common/http.py
@@ -37,6 +37,10 @@ class Client(object):
 
 
     def request(self, method, url, **kwargs):
+        # Default to management_url, but can be overridden here 
+        # (for auth requests)
+        base_url = kwargs.get('base_url', self.management_url)
+
         self.http_obj = httplib2.Http()
 
         params = {}
@@ -48,6 +52,7 @@ class Client(object):
         if 'body' in kwargs:
             params['body'] = kwargs.get('body')
 
-        req_url = "%s/%s" % (self.base_url, url)
+
+        req_url = os.path.join(base_url, url.strip('/'))
         resp, body = self.http_obj.request(req_url, method, **params)
         return resp, body

--- a/stacktester/common/http.py
+++ b/stacktester/common/http.py
@@ -52,7 +52,6 @@ class Client(object):
         if 'body' in kwargs:
             params['body'] = kwargs.get('body')
 
-
         req_url = os.path.join(base_url, url.strip('/'))
         resp, body = self.http_obj.request(req_url, method, **params)
         return resp, body

--- a/stacktester/config.py
+++ b/stacktester/config.py
@@ -35,6 +35,11 @@ class NovaConfig(object):
         return self.get("base_url", "/v1.1")
 
     @property
+    def project_id(self):
+        """Base of the HTTP API URL. Defaults to '/v1.1'."""
+        return self.get("project_id", "admin")
+
+    @property
     def api_key(self):
         """API key to use when authenticating. Defaults to 'admin_key'."""
         return self.get("api_key", "admin_key")

--- a/stacktester/openstack.py
+++ b/stacktester/openstack.py
@@ -11,4 +11,5 @@ class Manager(object):
                                     self.config.nova.port,
                                     self.config.nova.base_url,
                                     self.config.nova.username,
-                                    self.config.nova.api_key)
+                                    self.config.nova.api_key,
+                                    self.config.nova.project_id)

--- a/stacktester/tests/test_flavors.py
+++ b/stacktester/tests/test_flavors.py
@@ -51,7 +51,9 @@ class FlavorsTest(unittest.TestCase):
         host = self.os.config.nova.host
         port = self.os.config.nova.port
         api_url = '%s:%s' % (host, port)
-        base_url = os.path.join(api_url, self.os.config.nova.base_url)
+        base_url = os.path.join(api_url, self.os.config.nova.base_url,
+                                self.os.config.nova.project_id)
+        api_url = os.path.join(api_url, self.os.config.nova.project_id)
 
         self_link = 'http://' + os.path.join(base_url, 'flavors', flavor_id)
         bookmark_link = 'http://' + os.path.join(api_url, 'flavors', flavor_id)

--- a/stacktester/tests/test_images.py
+++ b/stacktester/tests/test_images.py
@@ -22,8 +22,12 @@ class ImagesTest(unittest.TestCase):
     def _assert_image_links(self, image):
         image_id = str(image['id'])
 
-        self_link = 'http://' + os.path.join(self.api_url, 'images', image_id)
-        bookmark_link = 'http://' + os.path.join(self.base_url, 'images', image_id)
+        self_link = 'http://' + os.path.join(self.api_url,
+                                             self.os.config.nova.project_id,
+                                             'images', image_id)
+        bookmark_link = 'http://' + os.path.join(self.base_url,
+                                             self.os.config.nova.project_id,
+                                             'images', image_id)
 
         expected_links = [
             {

--- a/stacktester/tests/test_server_actions.py
+++ b/stacktester/tests/test_server_actions.py
@@ -107,7 +107,7 @@ class ServerActionsTest(unittest.TestCase):
         self.assertTrue(initial_time_started < post_reboot_time_started)
 
     def test_reboot_server_hard(self):
-        """Rebood a server (HARD)"""
+        """Reboot a server (HARD)"""
 
         # SSH and get the uptime
         initial_time_started = self._get_boot_time()

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -54,8 +54,12 @@ class ServersTest(unittest.TestCase):
         api_url = '%s:%s' % (host, port)
         base_url = os.path.join(api_url, self.os.config.nova.base_url)
 
-        self_link = 'http://' + os.path.join(base_url, 'servers', server_id)
-        bookmark_link = 'http://' + os.path.join(api_url, 'servers', server_id)
+        self_link = 'http://' + os.path.join(base_url,
+                                             self.os.config.nova.project_id,
+                                             'servers', server_id)
+        bookmark_link = 'http://' + os.path.join(api_url,
+                                            self.os.config.nova.project_id,
+                                            'servers', server_id)
 
         expected_links = [
             {

--- a/stacktester/tests/test_servers.py
+++ b/stacktester/tests/test_servers.py
@@ -35,6 +35,8 @@ class ServersTest(unittest.TestCase):
             'flavor',
             'created',
             'updated',
+            'accessIPv4',
+            'accessIPv6',
 
             #KNOWN-ISSUE lp804093
             'uuid',


### PR DESCRIPTION
Makes stacktester use x-server-management-url as the base url for requests so that they will work with recent tenant_id changes in nova trunk.

Also updates the link/bookmark links in flavors/images/servers that we check for to have the tenant_id in them properly.
